### PR TITLE
Correct typos in inequality operators

### DIFF
--- a/files/en-us/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_equality/index.md
@@ -93,5 +93,5 @@ console.log(object1 === object1); // true
 ## See also
 
 - [Equality (`==`)](/en-US/docs/Web/JavaScript/Reference/Operators/Equality)
-- [Inequality (`!==`)](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
-- [Strict inequality (`!===`)](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)
+- [Inequality (`!=`)](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)
+- [Strict inequality (`!==`)](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I corrected `!==` and `!===` to `!=` and `!==`, respectively.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The typos mislead readers about the syntax.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The articles they link off to show the correct syntax for the operators:

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
